### PR TITLE
fixes typo in "create"

### DIFF
--- a/mysql/templates/Common/mysql-logrotate.j2
+++ b/mysql/templates/Common/mysql-logrotate.j2
@@ -2,5 +2,5 @@
   missingok
   rotate 2
   size 125M
-  craete 644 mysql mysql
+  create 644 mysql mysql
 }


### PR DESCRIPTION
This looks to be a simple typo, found it when backporting https://github.com/rackspace-orchestration-templates/lamp/pull/95
