### PR TITLE
moves include statement to fix a load order issue

### DIFF
--- a/apache/templates/RedHat/v24/httpd.conf.j2
+++ b/apache/templates/RedHat/v24/httpd.conf.j2
@@ -69,6 +69,7 @@ KeepAliveTimeout {{ keep_alive_timeout }}
 ## Server-Pool Size Regulation (MPM specific)
 ##
 
+Include conf.modules.d/*.conf
 # prefork MPM
 # StartServers: number of server processes to start
 # MinSpareServers: minimum number of server processes which are kept spare
@@ -114,7 +115,6 @@ KeepAliveTimeout {{ keep_alive_timeout }}
 # Example:
 # LoadModule foo_module modules/mod_foo.so
 #
-Include conf.modules.d/*.conf
 
 #
 # If you wish httpd to run as a different user or group, you must run


### PR DESCRIPTION
The current behavior is as follows:

apache loads the configuration, including the 'if prefork' bits. These are not applied because the prefork module has not been loaded.

The prefork module is then loaded by the include, but now without the settings that were set up. 

This simply moves the include further up to provide the anticipated behavior. Based on Steve McCracken's work on https://github.com/rackspace-orchestration-templates/lamp/pull/104
